### PR TITLE
Support command line arguments to customize application

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This repository was inspired by [kernelconcepts' `qt-mini-browser`](https://gith
 
 #### Test with Google
 ``` bash
-  ./web-renderer --title "Google" --url https://google.com --width 0.7 --height 0.8
+  ./web-renderer --window-title "Google" --url https://google.com --width 0.7 --height 0.8
 ```
 
 #### Fullscreen Local Server
 ``` bash
-  ./web-renderer --title "My Local Server" --url http://localhost --fullscreen
+  ./web-renderer --window-title "My Local Server" --url http://localhost --fullscreen
 ```

--- a/README.md
+++ b/README.md
@@ -6,12 +6,44 @@ This repository was inspired by [kernelconcepts' `qt-mini-browser`](https://gith
 
 ## Usage
 
-#### Test with Google
 ``` bash
-  ./web-renderer --window-title "Google" --url https://google.com --width 0.7 --height 0.8
+Usage: ./web-renderer [options] url
+Application that presents web content in a way that looks like a native application window
+
+Options:
+  -k, --kiosk                 Start in kiosk mode. In this mode, the
+                              application will start in fullscreen with minimal
+                              UI. It will prevent the user from quitting or
+                              performing any interaction outside of usage of the
+                              application
+  -s, --size <size>           Window size relative to screen, expressed as
+                              '<width_scalar>x<height_scalar>' (e.g. '0.6x0.4'),
+                              where each scalar is a decimal number from 0 to 1.
+  -t, --window-title <title>  Specify a title for the window. This will appear
+                              in the title bar.
+  -i, --icon <path>           Specify the path to an icon to be set as the
+                              application icon. This will appear in the title
+                              bar (unless the '--hide-frame' option is
+                              selected), and in the application bar.
+  --hide-frame                Hide the frame (title bar and border) of the
+                              window. This means there will be no 'close',
+                              'minimize' and 'maximize' buttons. Without this,
+                              the user cannot move or resize the window via the
+                              window system.
+  -h, --help                  Displays this help.
+
+Arguments:
+  url                         URL to open
 ```
 
-#### Fullscreen Local Server
+## Examples
+
+### Open Google
 ``` bash
-  ./web-renderer --window-title "My Local Server" --url http://localhost --fullscreen
+  $ web-renderer --window-title "Google" --size 0.7x0.8 http://www.google.com
+```
+
+### Fullscreen Local Server
+``` bash
+  $ web-renderer --window-title "My Local Server" --kiosk http://localhost:3000
 ```

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,10 @@ Depends:
  qml-module-qtquick2,
  qml-module-qtquick-controls2,
  qml-module-qtwebengine,
+Breaks:
+ pt-web-ui (<< 4.0.0),
+Replaces:
+ pt-web-ui (<< 4.0.0),
 Description: pi-top Web UI
  Minimal web browser intended for making web-served frontends appear
  native. Not designed to be used standalone. Internally configured based

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Standards-Version: 4.5.1
 Homepage: https://pi-top.com/
 
 Package: web-renderer
-Architecture: any
+Architecture: armhf
 Depends:
  ${misc:Depends},
  ${shlibs:Depends},

--- a/debian/web-renderer.manpages
+++ b/debian/web-renderer.manpages
@@ -1,0 +1,1 @@
+docs/web-renderer.1

--- a/docs/web-renderer.1
+++ b/docs/web-renderer.1
@@ -1,0 +1,34 @@
+.TH "WEB-RENDERER" 1
+.SH NAME
+web-renderer \- present web content in a native-looking window
+.SH SYNOPSIS
+web-renderer [options]
+.SH DESCRIPTION
+Application that presents web content in a way that looks like a native application window.
+The application will start in fullscreen mode by default.
+.SH OPTIONS
+--wm, --windowed            Start application in windowed mode.
+
+--ww, --width <width>       Window width relative to screen, from 0 to 1.
+
+--wh, --height <height>     Window height relative to screen, from 0 to 1.
+
+-u, --url <url>             URL to open. Defaults to localhost.
+
+-t, --window-title <title>  Specify a title for the window.
+
+-i, --icon <path>           Specify the path to an icon to be set as the application icon.
+
+--wf, --show-window-frame   Show the frame of the window.
+
+-h, --help                  Displays a help message.
+.SH EXAMPLE
+Open google in a window:
+$ web-renderer --window-title "Google" --url https://google.com --windowed --width 0.7 --height 0.8
+
+Open a local server in fullscreen:
+$ web-renderer --window-title "My Local Server" --url http://localhost:3000
+.SH BUGS
+No known bugs.
+.SH AUTHOR
+pi-top (deb-maintainers@pi-top.com)

--- a/docs/web-renderer.1
+++ b/docs/web-renderer.1
@@ -1,13 +1,15 @@
 .TH "WEB-RENDERER" 1
 .SH NAME
 web-renderer \- present web content in a native-looking window
+
 .SH SYNOPSIS
-web-renderer [options]
+web-renderer [options] url
+
 .SH DESCRIPTION
 Application that presents web content in a way that looks like a native application window.
 The application will start in fullscreen mode by default.
-.SH OPTIONS
 
+.SH OPTIONS
 
 .INDENT 0.0
 .TP
@@ -35,7 +37,7 @@ Specify the path to an icon to be set as the application icon. This will appear 
 
 .INDENT 0.0
 .TP
-.B --hide-window-frame
+.B --hide-frame
 Hide the frame (title bar and border) of the window. This means there will be no 'close', 'minimize' and 'maximize' buttons. Without this, the user cannot move or resize the window via the window system.
 .UNINDENT
 

--- a/docs/web-renderer.1
+++ b/docs/web-renderer.1
@@ -7,27 +7,58 @@ web-renderer [options]
 Application that presents web content in a way that looks like a native application window.
 The application will start in fullscreen mode by default.
 .SH OPTIONS
---wm, --windowed            Start application in windowed mode.
 
---ww, --width <width>       Window width relative to screen, from 0 to 1.
 
---wh, --height <height>     Window height relative to screen, from 0 to 1.
+.INDENT 0.0
+.TP
+.B -k, --kiosk
+Start in kiosk mode. In this mode, the application will start in fullscreen with minimal UI. It will prevent the user from quitting or performing any interaction outside of usage of the application
+.UNINDENT
 
--u, --url <url>             URL to open. Defaults to localhost.
+.INDENT 0.0
+.TP
+.B -s, --size <size>
+Window size relative to screen, expressed as '<width_scalar>x<height_scalar>' (e.g. '0.6x0.4'), where each scalar is a decimal number from 0 to 1.
+.UNINDENT
 
--t, --window-title <title>  Specify a title for the window.
+.INDENT 0.0
+.TP
+.B -t, --window-title <title>
+Specify a title for the window. This will appear in the title bar.
+.UNINDENT
 
--i, --icon <path>           Specify the path to an icon to be set as the application icon.
+.INDENT 0.0
+.TP
+.B -i, --icon <path>
+Specify the path to an icon to be set as the application icon. This will appear in the title bar (unless the '--hide-frame' option is selected), and in the application bar.
+.UNINDENT
 
---wf, --show-window-frame   Show the frame of the window.
+.INDENT 0.0
+.TP
+.B --hide-window-frame
+Hide the frame (title bar and border) of the window. This means there will be no 'close', 'minimize' and 'maximize' buttons. Without this, the user cannot move or resize the window via the window system.
+.UNINDENT
 
--h, --help                  Displays a help message.
+.INDENT 0.0
+.TP
+.B -h, --help
+Show a help message and exits.
+.UNINDENT
+
 .SH EXAMPLE
-Open google in a window:
-$ web-renderer --window-title "Google" --url https://google.com --windowed --width 0.7 --height 0.8
 
-Open a local server in fullscreen:
-$ web-renderer --window-title "My Local Server" --url http://localhost:3000
+.INDENT 0.0
+.TP
+.B Open Google in a window
+$ web-renderer --window-title "Google" --size 0.7x0.8 http://www.google.com
+.UNINDENT
+
+.INDENT 0.0
+.TP
+.B Open a local server in kiosk mode
+$ web-renderer --window-title "My Local Server" --kiosk http://localhost:3000
+.UNINDENT
+
 .SH BUGS
 No known bugs.
 .SH AUTHOR

--- a/docs/web-renderer.1
+++ b/docs/web-renderer.1
@@ -11,55 +11,39 @@ The application will start in fullscreen mode by default.
 
 .SH OPTIONS
 
-.INDENT 0.0
 .TP
 .B -k, --kiosk
 Start in kiosk mode. In this mode, the application will start in fullscreen with minimal UI. It will prevent the user from quitting or performing any interaction outside of usage of the application
-.UNINDENT
 
-.INDENT 0.0
 .TP
 .B -s, --size <size>
 Window size relative to screen, expressed as '<width_scalar>x<height_scalar>' (e.g. '0.6x0.4'), where each scalar is a decimal number from 0 to 1.
-.UNINDENT
 
-.INDENT 0.0
 .TP
 .B -t, --window-title <title>
 Specify a title for the window. This will appear in the title bar.
-.UNINDENT
 
-.INDENT 0.0
 .TP
 .B -i, --icon <path>
 Specify the path to an icon to be set as the application icon. This will appear in the title bar (unless the '--hide-frame' option is selected), and in the application bar.
-.UNINDENT
 
-.INDENT 0.0
 .TP
 .B --hide-frame
 Hide the frame (title bar and border) of the window. This means there will be no 'close', 'minimize' and 'maximize' buttons. Without this, the user cannot move or resize the window via the window system.
-.UNINDENT
 
-.INDENT 0.0
 .TP
 .B -h, --help
 Show a help message and exits.
-.UNINDENT
 
 .SH EXAMPLE
 
-.INDENT 0.0
 .TP
 .B Open Google in a window
 $ web-renderer --window-title "Google" --size 0.7x0.8 http://www.google.com
-.UNINDENT
 
-.INDENT 0.0
 .TP
 .B Open a local server in kiosk mode
 $ web-renderer --window-title "My Local Server" --kiosk http://localhost:3000
-.UNINDENT
 
 .SH BUGS
 No known bugs.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
   parser.addOption(urlOption);
   QCommandLineOption titleOption(QStringList() << "t" << "window-title", "Specify a title for the window. This will appear in the title bar.", "title", "web-renderer");
   parser.addOption(titleOption);
-  QCommandLineOption iconOption(QStringList() << "i" << "icon", "Specify the path to an icon to be set as the application icon.", "path", "");
+  QCommandLineOption iconOption(QStringList() << "i" << "icon", "Specify the path to an icon to be set as the application icon. This will appear in the title bar (unless the '--hide-frame' option is selected), and in the application bar.", "path", "");
   parser.addOption(iconOption);
   QCommandLineOption hideWindowFrameOption(QStringList() << "hide-window-frame", "Hide the frame (title bar and border) of the window. This means there will be no 'close', 'minimize' and 'maximize' buttons. Without this, the user cannot move or resize the window via the window system.");
   parser.addOption(hideWindowFrameOption);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,12 +115,10 @@ void waitForServerResponse(const QUrl url)
       qInfo() << "Backend web server responded!";
       break;
     }
-    else
-    {
-      qInfo()
-          << "Backend web server did not respond - sleeping for 1 second...";
-      QThread::sleep(1);
-    }
+
+    qInfo() << "Backend web server did not respond - sleeping for 1 second...";
+    QThread::sleep(1);
+    ++counter;
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
-#include <QGuiApplication>
+#include <QCommandLineOption>
 #include <QCommandLineParser>
+#include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QScreen>
 #include <QThread>
@@ -84,32 +85,31 @@ int runCommand(const QString &command, const QStringList &args, int timeout,
 
 int main(int argc, char *argv[])
 {
-  int defaultLoggingMode = LoggingMode::Console | LoggingMode::Journal;
-#ifdef QT_DEBUG
-  int defaultLogLevel = LOG_DEBUG;
-#else
-  int defaultLogLevel = LOG_INFO;
-#endif
-
-  PTLogger::initialiseLogger(defaultLoggingMode, defaultLogLevel);
 
   QGuiApplication app(argc, argv);
   QtWebEngine::initialize();
 
   QCommandLineParser parser;
-  parser.setApplicationDescription(QGuiApplication::applicationDisplayName());
-  QCommandLineOption windowedModeOption(QStringList() << "wm" << "windowed", "windowed mode");
+  parser.setApplicationDescription("Present web content in a way that looks like a native application window");
+  QCommandLineOption windowedModeOption(QStringList() << "wm" << "windowed", "Start application in windowed mode.");
   parser.addOption(windowedModeOption);
-  QCommandLineOption widthOption(QStringList() << "w" << "window-width", "window width relative to screen", "width", "0.65");
+  QCommandLineOption widthOption(QStringList() << "ww" << "width", "Window width relative to screen, from 0 to 1.", "width", "0.65");
   parser.addOption(widthOption);
-  QCommandLineOption heightOption(QStringList() << "h" << "window-height", "window height relative to screen", "height", "0.55");
+  QCommandLineOption heightOption(QStringList() << "wh" << "height", "Window height relative to screen, from 0 to 1.", "height", "0.55");
   parser.addOption(heightOption);
-  QCommandLineOption urlOption(QStringList() << "u" << "url", "url to open", "url", "http://localhost:80");
+  QCommandLineOption urlOption(QStringList() << "u" << "url", "URL to open. Defaults to localhost.", "url", "http://localhost:80");
   parser.addOption(urlOption);
-  QCommandLineOption titleOption(QStringList() << "t" << "window-title", "window title", "title", "");
+  QCommandLineOption titleOption(QStringList() << "t" << "title", "Specify a title for the window.", "title", "");
   parser.addOption(titleOption);
+  QCommandLineOption helpOption = parser.addHelpOption();
 
   parser.process(app);
+
+  if (parser.isSet(helpOption))
+  {
+    parser.showHelp();
+    return 0;
+  }
 
   bool windowedModeArg = parser.isSet(windowedModeOption);
 
@@ -123,6 +123,15 @@ int main(int argc, char *argv[])
 
   QString url = parser.value(urlOption);
   QString title = parser.value(titleOption);
+
+  int defaultLoggingMode = LoggingMode::Console | LoggingMode::Journal;
+#ifdef QT_DEBUG
+  int defaultLogLevel = LOG_DEBUG;
+#else
+  int defaultLogLevel = LOG_INFO;
+#endif
+
+  PTLogger::initialiseLogger(defaultLoggingMode, defaultLogLevel);
 
   QStringList args = app.arguments();
   qDebug() << args;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,8 +130,8 @@ int main(int argc, char *argv[])
 
   QCommandLineParser parser;
   parser.setApplicationDescription("Application that presents web content in a way that looks like a native application window");
-  QCommandLineOption windowedModeOption(QStringList() << "wm" << "windowed", "Start application in windowed mode.");
-  parser.addOption(windowedModeOption);
+  QCommandLineOption kioskModeOption(QStringList() << "k" << "kiosk", "Start in kiosk mode. In this mode, the application will start in fullscreen with minimal UI. It will prevent the user from quitting or performing any interaction outside of usage of the application");
+  parser.addOption(kioskModeOption);
   QCommandLineOption widthOption(QStringList() << "ww" << "width", "Window width relative to screen, from 0 to 1.", "width", "0.65");
   parser.addOption(widthOption);
   QCommandLineOption heightOption(QStringList() << "wh" << "height", "Window height relative to screen, from 0 to 1.", "height", "0.55");
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
     return 0;
   }
 
-  bool windowedModeArg = parser.isSet(windowedModeOption);
+  bool kioskModeArg = parser.isSet(kioskModeOption);
   bool showWindowFrameArg = parser.isSet(showWindowFrameOption);
 
   bool widthArg;
@@ -247,19 +247,21 @@ int main(int argc, char *argv[])
   rootObject->setProperty("title", titleArg);
 
   const QSize &screenSize = app.primaryScreen()->size();
-  if (windowedModeArg && widthArg)
-  {
-    rootObject->setProperty("width", width*screenSize.width());
-  }
-  if (windowedModeArg && heightArg)
-  {
-    rootObject->setProperty("height", height*screenSize.height());
-  }
-  if (! windowedModeArg)
+  if (kioskModeArg)
   {
     rootObject->setProperty("visibility", "FullScreen");
     rootObject->setProperty("width", screenSize.width());
     rootObject->setProperty("height", screenSize.height());
+  }
+  if (!kioskModeArg && widthArg)
+  {
+    rootObject->setProperty("visibility", "Windowed");
+    rootObject->setProperty("width", width*screenSize.width());
+  }
+  if (!kioskModeArg && heightArg)
+  {
+    rootObject->setProperty("visibility", "Windowed");
+    rootObject->setProperty("height", height*screenSize.height());
   }
   rootObject->setProperty("url", url);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
   parser.addOption(heightOption);
   QCommandLineOption urlOption(QStringList() << "u" << "url", "URL to open. Defaults to localhost.", "url", "http://localhost:80");
   parser.addOption(urlOption);
-  QCommandLineOption titleOption(QStringList() << "t" << "title", "Specify a title for the window.", "title", "web-renderer");
+  QCommandLineOption titleOption(QStringList() << "t" << "window-title", "Specify a title for the window.", "title", "web-renderer");
   parser.addOption(titleOption);
   QCommandLineOption iconOption(QStringList() << "i" << "icon", "Specify the path to an icon to be set as the application icon.", "path", "");
   parser.addOption(iconOption);
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
   float height = heightStr.toFloat(&heightArg);
 
   const QUrl url(parser.value(urlOption));
-  const QString title = parser.value(titleOption);
+  const QString titleArg = parser.value(titleOption);
   const QString iconArg = parser.value(iconOption);
 
   int defaultLoggingMode = LoggingMode::Console | LoggingMode::Journal;
@@ -243,8 +243,8 @@ int main(int argc, char *argv[])
   ////////////////
   qInfo() << "Configuring view";
 
-  app.setApplicationName(title);
-  rootObject->setProperty("title", title);
+  app.setApplicationName(titleArg);
+  rootObject->setProperty("title", titleArg);
 
   const QSize &screenSize = app.primaryScreen()->size();
   if (windowedModeArg && widthArg)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
   QtWebEngine::initialize();
 
   QCommandLineParser parser;
-  parser.setApplicationDescription("Present web content in a way that looks like a native application window");
+  parser.setApplicationDescription("Application that presents web content in a way that looks like a native application window");
   QCommandLineOption windowedModeOption(QStringList() << "wm" << "windowed", "Start application in windowed mode.");
   parser.addOption(windowedModeOption);
   QCommandLineOption widthOption(QStringList() << "ww" << "width", "Window width relative to screen, from 0 to 1.", "width", "0.65");
@@ -140,8 +140,10 @@ int main(int argc, char *argv[])
   parser.addOption(heightOption);
   QCommandLineOption urlOption(QStringList() << "u" << "url", "URL to open. Defaults to localhost.", "url", "http://localhost:80");
   parser.addOption(urlOption);
-  QCommandLineOption titleOption(QStringList() << "t" << "title", "Specify a title for the window.", "title", "");
+  QCommandLineOption titleOption(QStringList() << "t" << "title", "Specify a title for the window.", "title", "web-renderer");
   parser.addOption(titleOption);
+  QCommandLineOption showWindowFrameOption(QStringList() << "wf" << "show-window-frame", "Show the frame of the window.");
+  parser.addOption(showWindowFrameOption);
   QCommandLineOption helpOption = parser.addHelpOption();
 
   parser.process(app);
@@ -153,6 +155,7 @@ int main(int argc, char *argv[])
   }
 
   bool windowedModeArg = parser.isSet(windowedModeOption);
+  bool showWindowFrameArg = parser.isSet(showWindowFrameOption);
 
   bool widthArg;
   QString widthStr = parser.value(widthOption);
@@ -258,6 +261,13 @@ int main(int argc, char *argv[])
     rootObject->setProperty("height", screenSize.height());
   }
   rootObject->setProperty("url", url);
+
+  if (showWindowFrameArg)
+  {
+    window->setFlag(Qt::FramelessWindowHint, false);
+  }
+
+
   rootObject->setProperty("initialised", true);
 
   waitForServerResponse(url);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,6 +142,8 @@ int main(int argc, char *argv[])
   parser.addOption(urlOption);
   QCommandLineOption titleOption(QStringList() << "t" << "title", "Specify a title for the window.", "title", "web-renderer");
   parser.addOption(titleOption);
+  QCommandLineOption iconOption(QStringList() << "i" << "icon", "Specify the path to an icon to be set as the application icon.", "path", "");
+  parser.addOption(iconOption);
   QCommandLineOption showWindowFrameOption(QStringList() << "wf" << "show-window-frame", "Show the frame of the window.");
   parser.addOption(showWindowFrameOption);
   QCommandLineOption helpOption = parser.addHelpOption();
@@ -167,6 +169,7 @@ int main(int argc, char *argv[])
 
   const QUrl url(parser.value(urlOption));
   const QString title = parser.value(titleOption);
+  const QString iconArg = parser.value(iconOption);
 
   int defaultLoggingMode = LoggingMode::Console | LoggingMode::Journal;
 #ifdef QT_DEBUG
@@ -267,6 +270,11 @@ int main(int argc, char *argv[])
     window->setFlag(Qt::FramelessWindowHint, false);
   }
 
+  if (!iconArg.isEmpty())
+  {
+    const QIcon icon(iconArg);
+    app.setWindowIcon(icon);
+  }
 
   rootObject->setProperty("initialised", true);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
   parser.addOption(titleOption);
   QCommandLineOption iconOption(QStringList() << "i" << "icon", "Specify the path to an icon to be set as the application icon. This will appear in the title bar (unless the '--hide-frame' option is selected), and in the application bar.", "path", "");
   parser.addOption(iconOption);
-  QCommandLineOption hideWindowFrameOption(QStringList() << "hide-window-frame", "Hide the frame (title bar and border) of the window. This means there will be no 'close', 'minimize' and 'maximize' buttons. Without this, the user cannot move or resize the window via the window system.");
+  QCommandLineOption hideWindowFrameOption(QStringList() << "hide-frame", "Hide the frame (title bar and border) of the window. This means there will be no 'close', 'minimize' and 'maximize' buttons. Without this, the user cannot move or resize the window via the window system.");
   parser.addOption(hideWindowFrameOption);
   QCommandLineOption helpOption = parser.addHelpOption();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,12 +138,12 @@ int main(int argc, char *argv[])
   parser.addOption(heightOption);
   QCommandLineOption urlOption(QStringList() << "u" << "url", "URL to open. Defaults to localhost.", "url", "http://localhost:80");
   parser.addOption(urlOption);
-  QCommandLineOption titleOption(QStringList() << "t" << "window-title", "Specify a title for the window.", "title", "web-renderer");
+  QCommandLineOption titleOption(QStringList() << "t" << "window-title", "Specify a title for the window. This will appear in the title bar.", "title", "web-renderer");
   parser.addOption(titleOption);
   QCommandLineOption iconOption(QStringList() << "i" << "icon", "Specify the path to an icon to be set as the application icon.", "path", "");
   parser.addOption(iconOption);
-  QCommandLineOption showWindowFrameOption(QStringList() << "wf" << "show-window-frame", "Show the frame of the window.");
-  parser.addOption(showWindowFrameOption);
+  QCommandLineOption hideWindowFrameOption(QStringList() << "hide-window-frame", "Hide the frame (title bar and border) of the window. This means there will be no 'close', 'minimize' and 'maximize' buttons. Without this, the user cannot move or resize the window via the window system.");
+  parser.addOption(hideWindowFrameOption);
   QCommandLineOption helpOption = parser.addHelpOption();
 
   parser.process(app);
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
   }
 
   bool kioskModeArg = parser.isSet(kioskModeOption);
-  bool showWindowFrameArg = parser.isSet(showWindowFrameOption);
+  bool hideWindowFrameArg = parser.isSet(hideWindowFrameOption);
 
   bool widthArg;
   QString widthStr = parser.value(widthOption);
@@ -265,10 +265,7 @@ int main(int argc, char *argv[])
   }
   rootObject->setProperty("url", url);
 
-  if (showWindowFrameArg)
-  {
-    window->setFlag(Qt::FramelessWindowHint, false);
-  }
+  window->setFlag(Qt::FramelessWindowHint, hideWindowFrameArg);
 
   if (!iconArg.isEmpty())
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,6 +104,10 @@ int main(int argc, char *argv[])
   parser.addOption(widthOption);
   QCommandLineOption heightOption(QStringList() << "h" << "window-height", "window height relative to screen", "height", "0.55");
   parser.addOption(heightOption);
+  QCommandLineOption urlOption(QStringList() << "u" << "url", "url to open", "url", "http://localhost:80");
+  parser.addOption(urlOption);
+  QCommandLineOption titleOption(QStringList() << "t" << "window-title", "window title", "title", "");
+  parser.addOption(titleOption);
 
   parser.process(app);
 
@@ -116,6 +120,9 @@ int main(int argc, char *argv[])
   bool heightArg;
   QString heightStr = parser.value(heightOption);
   float height = heightStr.toFloat(&heightArg);
+
+  QString url = parser.value(urlOption);
+  QString title = parser.value(titleOption);
 
   QStringList args = app.arguments();
   qDebug() << args;
@@ -182,12 +189,8 @@ int main(int argc, char *argv[])
   ////////////////
   qInfo() << "Configuring view";
 
-  QString title = QStringLiteral("pi-topOS First Time Setup");
   app.setApplicationName(title);
   rootObject->setProperty("title", title);
-
-  QString url = "http://localhost:80";
-  rootObject->setProperty("url", url);
 
   const QSize &screenSize = app.primaryScreen()->size();
   if (windowedModeArg && widthArg)
@@ -204,6 +207,7 @@ int main(int argc, char *argv[])
     rootObject->setProperty("width", screenSize.width());
     rootObject->setProperty("height", screenSize.height());
   }
+  rootObject->setProperty("url", url);
   rootObject->setProperty("initialised", true);
 
   qInfo() << "Waiting for backend web server response...";


### PR DESCRIPTION
Closes #9 
Closes #21 
Closes #23

Support new command line arguments to customize how the application is displayed:
```
$ web-renderer --help
Usage: ./web-renderer [options] url
Application that presents web content in a way that looks like a native application window
Options:
  -k, --kiosk                 Start in kiosk mode. In this mode, the
                              application will start in fullscreen with minimal
                              UI. It will prevent the user from quitting or
                              performing any interaction outside of usage of the
                              application
  -s, --size <size>           Window size relative to screen, expressed as
                              '<width_scalar>x<height_scalar>' (e.g. '0.6x0.4'),
                              where each scalar is a decimal number from 0 to 1.
  -t, --window-title <title>  Specify a title for the window. This will appear
                              in the title bar.
  -i, --icon <path>           Specify the path to an icon to be set as the
                              application icon. This will appear in the title
                              bar (unless the '--hide-frame' option is
                              selected), and in the application bar.
  --hide-frame                Hide the frame (title bar and border) of the
                              window. This means there will be no 'close',
                              'minimize' and 'maximize' buttons. Without this,
                              the user cannot move or resize the window via the
                              window system.
  -h, --help                  Displays this help.
Arguments:
  url                         URL to open
```