### PR TITLE
Architecture: linux-any

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Standards-Version: 4.5.1
 Homepage: https://pi-top.com/
 
 Package: web-renderer
-Architecture: armhf
+Architecture: linux-any
 Depends:
  ${misc:Depends},
  ${shlibs:Depends},


### PR DESCRIPTION
`linux-any` matches [i2c-tools-extra](https://github.com/pi-top/i2c-tools-extra/blob/master/debian/control#L13). This allows for 64-bit environments to build the package.